### PR TITLE
Add Malloc Debugging

### DIFF
--- a/StikDebug/Device/JITEnableContext.swift
+++ b/StikDebug/Device/JITEnableContext.swift
@@ -17,6 +17,37 @@ typealias SyslogErrorHandler = (NSError?) -> Void
 final class JITEnableContext {
     static let shared = JITEnableContext()
 
+    private static func withCStringArray<R>(
+        _ strings: [String], _ body: (UnsafePointer<UnsafePointer<CChar>?>?, UInt) -> R
+    ) -> R {
+        if strings.isEmpty {
+            return body(nil, 0)
+        }
+        var cStrings: [UnsafeMutablePointer<CChar>?] = strings.map { strdup($0) }
+        defer { cStrings.forEach { free($0) } }
+        return cStrings.withUnsafeBufferPointer { buffer in
+            buffer.baseAddress!.withMemoryRebound(to: UnsafePointer<CChar>?.self, capacity: buffer.count) { rebound in
+                body(rebound, UInt(buffer.count))
+            }
+        }
+    }
+
+    private static func mallocDebugEnvVars() -> [String] {
+        let defaults = UserDefaults.standard
+        let enableAll = defaults.bool(forKey: UserDefaults.Keys.mallocDebug)
+        let guardEdges = enableAll || defaults.bool(forKey: UserDefaults.Keys.mallocGuardEdges)
+        let scribble = enableAll || defaults.bool(forKey: UserDefaults.Keys.mallocScribble)
+
+        var envVars: [String] = []
+        if guardEdges {
+            envVars.append("MallocGuardEdges=1")
+        }
+        if scribble {
+            envVars.append("MallocScribble=1")
+        }
+        return envVars
+    }
+
     private struct TunnelHandles {
         var adapter: OpaquePointer?
         var handshake: OpaquePointer?
@@ -603,7 +634,9 @@ final class JITEnableContext {
             try withProcessControl(remoteServer: remoteServer) { processControl in
                 var pid: UInt64 = 0
                 let ffiError = bundleID.withCString { bundleID in
-                    process_control_launch_app(processControl, bundleID, nil, 0, nil, 0, true, false, &pid)
+                    Self.withCStringArray(Self.mallocDebugEnvVars()) { envPtr, envCount in
+                        process_control_launch_app(processControl, bundleID, envPtr, envCount, nil, 0, true, false, &pid)
+                    }
                 }
 
                 if let ffiError {

--- a/StikDebug/Support/UserDefaults+Keys.swift
+++ b/StikDebug/Support/UserDefaults+Keys.swift
@@ -15,5 +15,9 @@ extension UserDefaults {
         static let defaultScriptName = "DefaultScriptName"
         static let defaultScriptNameValue = ""
         static let targetDeviceIP = "TunnelDeviceIP"
+        /// Attaches processes with MallocGuardEdges and MallocScribble.
+        static let mallocDebug = "enableMallocDebug"
+        static let mallocGuardEdges = "enableMallocGuardEdges"
+        static let mallocScribble = "enableMallocScribble"
     }
 }

--- a/StikDebug/Views/SettingsView.swift
+++ b/StikDebug/Views/SettingsView.swift
@@ -135,7 +135,7 @@ struct SettingsView: View {
                 Section("Debugging") {
                     Toggle(isOn: $mallocDebug) {
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("MallocGuardEdges / MallocScribble")
+                            Text("Malloc Debugging")
                             Text("Attaches processes with MallocGuardEdges and MallocScribble to detect memory corruption.")
                                 .font(.caption).foregroundStyle(.secondary)
                         }

--- a/StikDebug/Views/SettingsView.swift
+++ b/StikDebug/Views/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @AppStorage("keepAliveAudio") private var keepAliveAudio = true
     @AppStorage("keepAliveLocation") private var keepAliveLocation = true
     @AppStorage(UserDefaults.Keys.targetDeviceIP) private var targetDeviceIP = DeviceConnectionContext.defaultTargetIPAddress
+    @AppStorage(UserDefaults.Keys.mallocDebug) private var mallocDebug = false
 
     @State private var isShowingPairingFilePicker = false
     @State private var isImportingFile = false
@@ -126,6 +127,16 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Always Run Scripts")
                             Text("Treats device as TXM-capable to bypass hardware checks.")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section("Debugging") {
+                    Toggle(isOn: $mallocDebug) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("MallocGuardEdges / MallocScribble")
+                            Text("Attaches processes with MallocGuardEdges and MallocScribble to detect memory corruption.")
                                 .font(.caption).foregroundStyle(.secondary)
                         }
                     }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

Added a debugging section where you can enable malloc debugging. Used to detect memory corruption.

## Changes

- SettingsView.swift
- JITEnableContext.swift
- UserDefaults+Keys.swift

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
N/A

## Testing

- [x] Tested on device
- [x] Tested with fresh pairing file
- [x] No regressions in existing functionality

## Screenshots

<!-- If applicable, add screenshots showing the changes -->

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/adba33ac-6bdd-4012-aac3-2cfc5af15d9d" />

